### PR TITLE
Update chat broadcasting to include sender

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,9 +38,9 @@ wss.on('connection', (ws) => {
           chatroom.messages = [];
         }
         chatroom.messages.push(parsedMessage.message);
-        // Broadcast the message to all members of the chatroom
+        // Broadcast the message to all members of the chatroom, including the sender
         chatroom.members.forEach(member => {
-          if (member.ws !== ws && member.ws.readyState === WebSocket.OPEN) {
+          if (member.ws.readyState === WebSocket.OPEN) {
             member.ws.send(JSON.stringify({ type: 'message', message: parsedMessage.message }));
           }
         });


### PR DESCRIPTION
Related to #1

Updates the chat functionality in `app.js` to ensure messages are broadcasted to all users, including the sender.

- Modifies the message broadcasting logic within the WebSocket connection event. Now, when a message is sent, it is broadcasted to all members of the chatroom, including the sender. This change ensures that the sender can see their own messages in the chat, aligning with the after-change objectives.
- Maintains the existing functionality for broadcasting active chatrooms and sending chat history to clients when they join a chatroom.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/screwyforcepush/Kented/issues/1?shareId=ea7fff92-96eb-438f-b7e8-c10236c53bb2).